### PR TITLE
fixed wishlist for sheets, stalked flag

### DIFF
--- a/modules/wishlist-manage.js
+++ b/modules/wishlist-manage.js
@@ -153,9 +153,9 @@ async function dump_as_csv_string() {
             wishlists[hunter].helper,
             wishlists[hunter].helperId,
             wishlists[hunter].helperDiscordId,
-            'stalked' in wishlists[hunter],
+            'stalked' in wishlists[hunter] ? wishlists[hunter].stalked : false,
             'can_see_santa' in wishlists[hunter] ? wishlists[hunter].can_see_santa : false,
-            wishlists[hunter].wishlist,
+            '"' + wishlists[hunter].wishlist.replace(/"/g, '""') + '"',
         ]);
     }
     // Build a long string of CSV

--- a/restore_from_csv.js
+++ b/restore_from_csv.js
@@ -14,8 +14,8 @@ fs.readFile('assignments.csv', 'utf8', function(err, data) {
                 'helper': values[3],
                 'helperId': values[4],
                 'helperDiscordId': values[5],
-                'stalked': values[6] == 'true',
-                'can_see_santa': values[7] == 'true',
+                'stalked': values[6] === 'true',
+                'can_see_santa': values[7] === 'true',
                 'wishlist': values[8].slice(1, -1).replace(/""/g, '"'),
             };
         }

--- a/restore_from_csv.js
+++ b/restore_from_csv.js
@@ -16,7 +16,7 @@ fs.readFile('assignments.csv', 'utf8', function(err, data) {
                 'helperDiscordId': values[5],
                 'stalked': values[6] == 'true',
                 'can_see_santa': values[7] == 'true',
-                'wishlist': values[8],
+                'wishlist': values[8].slice(1, -1).replace(/""/g, '"'),
             };
         }
     });


### PR DESCRIPTION
Wishlists in the dump now become quote delimited with the embedded quotes escaped. Sheets like that better when there are commas in the data.

Also fixed the bug where "stalked" was always exported as true if it existed - imports can now set it to false.